### PR TITLE
Fix error that refunds executed via backend get signed before payment

### DIFF
--- a/pos_registrierkasse/__init__.py
+++ b/pos_registrierkasse/__init__.py
@@ -2,4 +2,4 @@
 
 from . import models
 from . import controllers
-
+from . import wizard

--- a/pos_registrierkasse/models/pos_order.py
+++ b/pos_registrierkasse/models/pos_order.py
@@ -9,19 +9,19 @@ from .utils.revenue_counter import encrypt_revenue_counter
 class CustomPOSOrder(models.Model):
     _inherit = 'pos.order'
 
-    encrypted_revenue = fields.Char(string='Encrypted revenue counter', translate=True)
-    order_signature = fields.Char(string='Signature from signing unit', translate=True)
-    prev_order_signature = fields.Char(string='Signature of the previous invoice', translate=True)
-    machine_readable_code = fields.Char(string='The whole code sent to A-Trust', translate=True)
-    certificate_serial_number = fields.Char(string='Serial number of the certificate', translate=True)
+    encrypted_revenue = fields.Char(string='Encrypted revenue counter')
+    order_signature = fields.Char(string='Signature from signing unit')
+    prev_order_signature = fields.Char(string='Signature of the previous invoice')
+    machine_readable_code = fields.Char(string='The whole code sent to A-Trust')
+    certificate_serial_number = fields.Char(string='Serial number of the certificate')
     registrierkasse_receipt_number = fields.Integer(string='Sequence of receipt specific to RKSV ', index=True)
 
-    sum_vat_normal = fields.Float(string='VAT Normal', digits=(16, 2), required=True, default=0)
-    sum_vat_discounted_1 = fields.Float(string='VAT Discounted 1', digits=(16, 2), required=True, default=0)
-    sum_vat_discounted_2 = fields.Float(string='VAT Discounted 2', digits=(16, 2), required=True, default=0)
-    sum_vat_null = fields.Float(string='VAT null', digits=(16, 2), required=True, default=0)
-    sum_vat_special = fields.Float(string='VAT special', digits=(16, 2), required=True, default=0)
-    sum_total_rksv = fields.Float(string='Total sum', digits=(16, 2), required=True, default=0)
+    sum_vat_normal = fields.Float(string='VAT Normal', digits=(16, 2), copy=False, required=True, default=0)
+    sum_vat_discounted_1 = fields.Float(string='VAT Discounted 1', digits=(16, 2), copy=False, required=True, default=0)
+    sum_vat_discounted_2 = fields.Float(string='VAT Discounted 2', digits=(16, 2), copy=False, required=True, default=0)
+    sum_vat_null = fields.Float(string='VAT null', digits=(16, 2), copy=False, required=True, default=0)
+    sum_vat_special = fields.Float(string='VAT special', digits=(16, 2), copy=False, required=True, default=0)
+    sum_total_rksv = fields.Float(string='Total sum', digits=(16, 2), copy=False, required=True, default=0)
 
     def _generate_pos_reference(self, order):
         """Generate a consistent pos_reference for an order."""
@@ -170,57 +170,6 @@ class CustomPOSOrder(models.Model):
 
         return order_id
 
-    def _prepare_refund_values(self, current_session):
-        self.ensure_one()
-        values = super()._prepare_refund_values(current_session)
-        values.update({
-            'registrierkasse_receipt_number': None,
-            'order_signature': None,
-            'prev_order_signature': None,
-            'machine_readable_code': None,
-            'encrypted_revenue': None,
-            'certificate_serial_number': None,
-        })
-        return values
-
-    def _refund(self):
-        refund_orders = super()._refund()
-
-        for order in self:
-            refund_order = refund_orders.filtered(lambda r: r.refunded_order_id == order)
-            if not refund_order:
-                continue
-
-            config = refund_order.session_id.config_id
-            if not config.pos_use_registrierkasse:
-                continue
-
-            refund_order.write({
-                'sum_vat_normal': -order.sum_vat_normal,
-                'sum_vat_discounted_1': -order.sum_vat_discounted_1,
-                'sum_vat_discounted_2': -order.sum_vat_discounted_2,
-                'sum_vat_null': -order.sum_vat_null,
-                'sum_vat_special': -order.sum_vat_special,
-            })
-
-            refund_vals = {
-                'amount_total': refund_order.amount_total,
-                'date_order': refund_order.date_order,
-                'sum_vat_normal': refund_order.sum_vat_normal,
-                'sum_vat_discounted_1': refund_order.sum_vat_discounted_1,
-                'sum_vat_discounted_2': refund_order.sum_vat_discounted_2,
-                'sum_vat_null': refund_order.sum_vat_null,
-                'sum_vat_special': refund_order.sum_vat_special,
-            }
-
-            rksv_data = self._get_rksv_signature(config, refund_vals, is_refund=True)
-            refund_order.write(rksv_data)
-
-            new_ref = self._generate_pos_reference(refund_order)
-            refund_order.write({'pos_reference': new_ref})
-
-        return refund_orders
-
     def unlink(self):
         """Prevent deletion of RKSV-signed orders."""
         for order in self:
@@ -246,12 +195,12 @@ class CustomPOSOrder(models.Model):
             is_refund = self._is_rksv_refund(order.lines)
 
             order_vals = {
-                'amount_total': order.amount_total,
+                'sum_total_rksv': order.amount_total,
                 **sums
             }
 
             try:
                 rksv_data = self._get_rksv_signature(config, order_vals, is_refund=is_refund)
-                order.write(rksv_data)
+                order.write(order_vals | rksv_data)
             except Exception as e:
                 raise UserError(_("Signing failed: %s") % str(e))

--- a/pos_registrierkasse/wizard/__init__.py
+++ b/pos_registrierkasse/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import pos_payment

--- a/pos_registrierkasse/wizard/pos_payment.py
+++ b/pos_registrierkasse/wizard/pos_payment.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+
+class PosMakePayment(models.TransientModel):
+    _inherit = 'pos.make.payment'
+
+    def check(self):
+        res = super().check()
+        order = self.env['pos.order'].browse(self.env.context.get('active_id', False))
+        if order.state in {'paid', 'done', 'invoiced'}:
+            order.action_retry_signing()
+        return res


### PR DESCRIPTION
When the user triggers a refund via the backend, the order is in state draft allowing the user to modify it before committing, but the RKSV signature is applied before, resulting in a wrong order being signed and added to the revenue counter.

* Technical RKSV fields do not need translation
* Calculatory RKSV fields should not be copied over when copying orders (the internal Odoo logic copies the order once the user triggers a refund) this renders _prepare_refund_values() unnecessary as values do not need to be removed, as this is done in action_retry_signing() right before signing
* Extend payment wizard to trigger RKSV signing only once payment is confirmed