### PR TITLE
Change revenue counter to integer

### DIFF
--- a/pos_registrierkasse/__manifest__.py
+++ b/pos_registrierkasse/__manifest__.py
@@ -15,7 +15,7 @@
     # Check https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Sales',
-    'version': '0.2',
+    'version': '0.3',
     'license': 'LGPL-3',
     'images': ['images/registrierkasse_thumbnail.png'],
 

--- a/pos_registrierkasse/i18n/de.po
+++ b/pos_registrierkasse/i18n/de.po
@@ -172,6 +172,11 @@ msgid "If this lock is set, RKSV settings can not be changed"
 msgstr "RKSV Einstellungen gesperrt"
 
 #. module: pos_registrierkasse
+#: model:ir.model.fields,field_description:pos_registrierkasse.field_pos_config__revenue_counter
+msgid "Internal Revenue Counter"
+msgstr "Interner Umsatzzähler"
+
+#. module: pos_registrierkasse
 #. odoo-javascript
 #: code:addons/pos_registrierkasse/static/src/overrides/pos_receipt_extension.xml:0
 msgid "Kassenidentifikationsnummer:"
@@ -291,6 +296,11 @@ msgstr "Der Name des POS muss eindeutig sein!"
 #: model:ir.model.fields,field_description:pos_registrierkasse.field_pos_order__machine_readable_code
 msgid "The whole code sent to A-Trust"
 msgstr "Maschinenlesbarer Code"
+
+#. module: pos_registrierkasse
+#: model:ir.model.fields,field_description:pos_registrierkasse.field_pos_config__display_revenue_counter
+msgid "RKSV Revenue Counter"
+msgstr "Umsatzzähler"
 
 #. module: pos_registrierkasse
 #: model:ir.model.fields,help:pos_registrierkasse.field_pos_config__receipt_sequence_id

--- a/pos_registrierkasse/migrations/0.3/post-migrate.py
+++ b/pos_registrierkasse/migrations/0.3/post-migrate.py
@@ -1,0 +1,15 @@
+import logging
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    _logger.info("RKSV: Running migration script for version 0.3.")
+    configs = env['pos.config'].search([('pos_use_registrierkasse', '=', True)])
+    _logger.info(f"RKSV: Found {len(configs)} RKSV-enabled POS configs to process.")
+    for config in configs:
+        _logger.info(f"RKSV: Creating/updating cron job for POS config '{config.name}' (ID: {config.id}).")
+        orders = env['pos.order'].search([('config_id', '=', config.id), ('registrierkasse_receipt_number', '!=', None)])
+        config.revenue_counter = sum(int(order.sum_total_rksv * 100.0) for order in orders)
+    _logger.info("RKSV: Finished migration script for version 0.3.")

--- a/pos_registrierkasse/models/pos_config.py
+++ b/pos_registrierkasse/models/pos_config.py
@@ -25,7 +25,8 @@ class CustomPOSConfig(models.Model):
 
     registrierkasse_aes_key = fields.Char(string='Umsatzzähler AES', translate=True)
     registrierkasse_aes_key_checksum = fields.Char(string='Umsatzzähler AES Prüfsumme', translate=True)
-    revenue_counter = fields.Float(string='Total', digits=0, default=0)
+    revenue_counter = fields.Integer(string='Internal Revenue Counter', default=0, copy=False)
+    display_revenue_counter = fields.Float("RKSV Revenue Counter", compute="_display_revenue_counter")
 
     a_trust_user_name = fields.Char(string='A-Trust User Name')
     a_trust_password = fields.Char(string='A-Trust Password')
@@ -84,6 +85,10 @@ class CustomPOSConfig(models.Model):
             'use_date_range': False,
         })
         return sequence
+
+    def _display_revenue_counter(self):
+        for record in self:
+            record.display_revenue_counter = record.revenue_counter / 100.0
 
     def _get_null_product(self):
         product_tmpl = self.env['product.template'].search([('name', '=', 'Nullbelegprodukt')], limit=1)

--- a/pos_registrierkasse/models/pos_order.py
+++ b/pos_registrierkasse/models/pos_order.py
@@ -33,9 +33,9 @@ class CustomPOSOrder(models.Model):
     def _get_rksv_signature(self, config, order_vals, is_refund=False):
         """Helper method to perform RKSV signing."""
         if "sum_total_rksv" in order_vals:
-            config.revenue_counter += order_vals.get('sum_total_rksv', 0.0)
+            config.revenue_counter += order_vals.get('sum_total_rksv', 0.0) * 100.0
         else:
-            config.revenue_counter += order_vals.get('amount_total', 0.0)
+            config.revenue_counter += order_vals.get('amount_total', 0.0) * 100.0
 
         receipt_number = int(config.receipt_sequence_id.next_by_id())
 

--- a/pos_registrierkasse/models/utils/dep_rebuild.py
+++ b/pos_registrierkasse/models/utils/dep_rebuild.py
@@ -31,7 +31,11 @@ def rebuild_dep(config, rehash_start=False):
                 order.machine_readable_code = split_mrc(order.machine_readable_code)
                 continue
         else:
-            revenue_counter += order.sum_vat_normal + order.sum_vat_discounted_1 + order.sum_vat_discounted_2 + order.sum_vat_null + order.sum_vat_special
+            revenue_counter += int(order.sum_vat_normal * 100.0) \
+                + int(order.sum_vat_discounted_1 * 100.0) \
+                + int(order.sum_vat_discounted_2 * 100.0) \
+                + int(order.sum_vat_null * 100.0) \
+                + int(order.sum_vat_special * 100.0)
 
             prev_order = config.env['pos.order'].search(
                 [('registrierkasse_receipt_number', '=', int(receipt_number) - 1),
@@ -50,7 +54,7 @@ def rebuild_dep(config, rehash_start=False):
 
         order.machine_readable_code = OrderData(
             config.name,
-            receipt_number,
+            str(receipt_number),
             format_order_date(str(order.date_order)),
             order.sum_vat_normal,
             order.sum_vat_discounted_1,

--- a/pos_registrierkasse/models/utils/revenue_counter.py
+++ b/pos_registrierkasse/models/utils/revenue_counter.py
@@ -6,15 +6,13 @@ import os
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 
-def encrypt_revenue_counter(revenue_counter: float, aes_key, pos_name, sequence_number):
+def encrypt_revenue_counter(revenue_counter: int, aes_key, pos_name, sequence_number):
     cipher = Cipher(algorithms.AES(b64decode(aes_key)), _init_vector(pos_name, sequence_number))
     encryptor = cipher.encryptor()
 
-    revenue_counter_cents = round(revenue_counter * 100)
-
     # According to the detailed Specification, the length of a block needs to be 16 Bytes.
     # However for the qr code it needs to be 5 bytes. So the first 5 bytes of the revenue counter are filled
-    data = revenue_counter_cents.to_bytes(5, byteorder='big', signed=True) + b'\x00' * 11
+    data = revenue_counter.to_bytes(5, byteorder='big', signed=True) + b'\x00' * 11
 
     encrypted = (encryptor.update(data) + encryptor.finalize())[:5]
     return b64encode(encrypted).decode('utf-8')
@@ -44,7 +42,7 @@ class PosUtilsTest(unittest.TestCase):
                           "Init vector string")
 
     def test_revenue_counter(self):
-        self.assertEqual(encrypt_revenue_counter(0.0,
+        self.assertEqual(encrypt_revenue_counter(0,
                                                  "mWSdfdY96cjlFE5+eKCzcXinWuBzhJvmMJ60QRvBJLI=",
                                                  "demokasse42",
                                                  1),
@@ -52,7 +50,7 @@ class PosUtilsTest(unittest.TestCase):
                          "Revenue counter 0")
 
     def test_decrypt_revenue_counter_zero(self):
-        encrypted = b64decode(encrypt_revenue_counter(0.0,
+        encrypted = b64decode(encrypt_revenue_counter(0,
                                                       self.AES_KEY,
                                                       "DEMO-CASH-BOX",
                                                       1))
@@ -62,7 +60,7 @@ class PosUtilsTest(unittest.TestCase):
         self.assertEqual(int_value, 0)
 
     def test_decrypt_revenue_counter_negatuve(self):
-        encrypted = b64decode(encrypt_revenue_counter(-10.0,
+        encrypted = b64decode(encrypt_revenue_counter(-1000,
                                                       self.AES_KEY,
                                                       "DEMO-CASH-BOX",
                                                       1))
@@ -72,7 +70,7 @@ class PosUtilsTest(unittest.TestCase):
         self.assertEqual(int_value, -1000)
 
     def test_decrypt_revenue_counter_positive(self):
-        encrypted = b64decode(encrypt_revenue_counter(22.0,
+        encrypted = b64decode(encrypt_revenue_counter(2200,
                                                       self.AES_KEY,
                                                       "DEMO-CASH-BOX",
                                                       1))
@@ -82,7 +80,7 @@ class PosUtilsTest(unittest.TestCase):
         self.assertEqual(int_value, 2200)
 
     def test_decrypt_revenue_counter_after_addition_with_one_decimal_place(self):
-        encrypted = b64decode(encrypt_revenue_counter(1.2 + 2.4,
+        encrypted = b64decode(encrypt_revenue_counter(120 + 240,
                                                       self.AES_KEY,
                                                       "DEMO-CASH-BOX",
                                                       1))
@@ -92,7 +90,7 @@ class PosUtilsTest(unittest.TestCase):
         self.assertEqual(int_value, 360)
 
     def test_decrypt_revenue_counter_after_addition_with_two_decimal_places(self):
-        encrypted = b64decode(encrypt_revenue_counter(3.33 + 3.11,
+        encrypted = b64decode(encrypt_revenue_counter(333 + 311,
                                                       self.AES_KEY,
                                                       "DEMO-CASH-BOX",
                                                       1))

--- a/pos_registrierkasse/views/pos_config.xml
+++ b/pos_registrierkasse/views/pos_config.xml
@@ -31,6 +31,9 @@
                                            class="col-lg-4 o_light_label"/>
                                     <field name="registrierkasse_aes_key_checksum" class="col-lg-4"
                                            readonly="true"/>
+                                    <label for="display_revenue_counter" string="Revenue Counter"
+                                           class="col-lg-4 o_light_label" invisible="not pos_rksv_lock"/>
+                                    <field name="display_revenue_counter" class="col-lg-4" invisible="not pos_rksv_lock"/>
                                 </div>
                                 <div class="row mt16">
                                     <label for="a_trust_environment" string="A-Trust Environment"
@@ -57,6 +60,17 @@
                         </setting>
                     </div>
                 </xpath>
+            </field>
+        </record>
+
+        <record id="view_pos_config_tree_registrierkasse" model="ir.ui.view">
+            <field name="name">pos.config.list.view.registrierkasse</field>
+            <field name="model">pos.config</field>
+            <field name="inherit_id" ref="point_of_sale.view_pos_config_tree"/>
+            <field name="arch" type="xml">
+                <field name="last_session_closing_cash" position="after">
+                    <field name="display_revenue_counter" widget="monetary" invisible="not pos_use_registrierkasse" optional="hide" />
+                </field>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Changes the revenue counter to interger and adds it to the settings page of the POS configuration. Details and rationale see #41.

Migration script to recalculate the revenue counter (conversion from float to integer is supported natively by Odoo, but to be on the safe side and catch some potential corner cases).

Requires some more intensive testing. I've tested the conversion only once from 0.2 to 0.3. The function of the integer counter was tested more intensively.